### PR TITLE
Displays a better error message when a user forgets to name all arguments

### DIFF
--- a/ginkgo_ai_client/queries.py
+++ b/ginkgo_ai_client/queries.py
@@ -2,25 +2,26 @@
 
 from typing import Dict, Optional, Any, List
 from abc import ABC, abstractmethod
-import inspect
 
 import pydantic
 
 
 class QueryBase(pydantic.BaseModel, ABC):
-
-    _example_params: str = "field_name=value, ..."
+    """Base class for all queries. It's functions are:
+    - Specify the mandatory class methods `to_request_params` and `parse_response`
+    - Provide a better error message when a user forgets to use named arguments only.
+      Without that tweak, the default error message from pydantic is very technical
+      and confusing to new users.
+    """
 
     def __new__(cls, *args, **kwargs):
         if args:
-            model_name = cls.__name__
-            example_params = cls._example_params
             raise TypeError(
-                f"Invalid initialization: {model_name} does "
-                f"not accept positional arguments. Please use keyword arguments instead "
-                f"for instance:\n\n {model_name}({example_params})."
+                f"Invalid initialization: {cls.__name__} does not accept unnamed "
+                f"arguments. Please name all inputs, for instance "
+                f"`{cls.__name__}(field_name=value, other_field=value, ...)`."
             )
-        return super().__new__(cls, **kwargs)
+        return super().__new__(cls)
 
     @abstractmethod
     def to_request_params(self) -> Dict:
@@ -105,8 +106,6 @@ class MeanEmbeddingQuery(QueryBase):
     sequence: str
     model: str
     query_name: Optional[str] = None
-
-    _example_params: str = "sequence='MLPP<mask>PPLM', model='ginkgo-aa0-650M'"
 
     def to_request_params(self) -> Dict:
         return {

--- a/ginkgo_ai_client/queries.py
+++ b/ginkgo_ai_client/queries.py
@@ -1,12 +1,26 @@
 """Classes to define queries to the Ginkgo AI API."""
 
 from typing import Dict, Optional, Any, List
-import pydantic
 from abc import ABC, abstractmethod
+import inspect
+
+import pydantic
 
 
 class QueryBase(pydantic.BaseModel, ABC):
-    query_name: Optional[str] = None
+
+    _example_params: str = "field_name=value, ..."
+
+    def __new__(cls, *args, **kwargs):
+        if args:
+            model_name = cls.__name__
+            example_params = cls._example_params
+            raise TypeError(
+                f"Invalid initialization: {model_name} does "
+                f"not accept positional arguments. Please use keyword arguments instead "
+                f"for instance:\n\n {model_name}({example_params})."
+            )
+        return super().__new__(cls, **kwargs)
 
     @abstractmethod
     def to_request_params(self) -> Dict:
@@ -91,6 +105,8 @@ class MeanEmbeddingQuery(QueryBase):
     sequence: str
     model: str
     query_name: Optional[str] = None
+
+    _example_params: str = "sequence='MLPP<mask>PPLM', model='ginkgo-aa0-650M'"
 
     def to_request_params(self) -> Dict:
         return {

--- a/test/test_query_creation.py
+++ b/test/test_query_creation.py
@@ -1,0 +1,13 @@
+import pytest
+import re
+from ginkgo_ai_client.queries import MeanEmbeddingQuery
+
+
+def test_that_forgetting_to_name_arguments_raises_the_better_error_message():
+    expected_error_message = re.escape(
+        "Invalid initialization: MeanEmbeddingQuery does not accept unnamed arguments. "
+        "Please name all inputs, for instance "
+        "`MeanEmbeddingQuery(field_name=value, other_field=value, ...)`."
+    )
+    with pytest.raises(TypeError, match=expected_error_message):
+        MeanEmbeddingQuery("MLLK<mask>P", model="ginkgo-aa0-650M")


### PR DESCRIPTION
By default pydantic has a confusing error message when users forget to name arguments ("0 arguments expected, 1 provided"), this replaces it with a more explicit injunction to name all arguments.