### PR TITLE
update promoter activity inference

### DIFF
--- a/examples/promoter_activity.py
+++ b/examples/promoter_activity.py
@@ -14,6 +14,7 @@ promoter_sequence = "GTCCCACTGATGAACTGTGCT"
 query = PromoterActivityQuery(
     promoter_sequence=promoter_sequence,
     orf_sequence=orf_sequence,
+    source="expression",
     tissue_of_interest={
         "heart": ["CNhs10608+", "CNhs10612+"],
         "liver": ["CNhs10608+", "CNhs10612+"],
@@ -31,6 +32,7 @@ fasta_path = Path(__file__).parent / "data" / "100_dna_sequences.fasta"
 queries = PromoterActivityQuery.iter_with_promoter_from_fasta(
     fasta_path=fasta_path,
     orf_sequence=orf_sequence,
+    source="expression",
     tissue_of_interest={
         "heart": ["CNhs10608+", "CNhs10612+"],
         "liver": ["CNhs10608+", "CNhs10612+"],

--- a/ginkgo_ai_client/queries.py
+++ b/ginkgo_ai_client/queries.py
@@ -270,6 +270,7 @@ class PromoterActivityQuery(QueryBase):
     promoter_sequence: str
     orf_sequence: str
     tissue_of_interest: Dict[str, List[str]]
+    source: str 
     model: str = "borzoi-human-fold0"
     query_name: Optional[str] = None
 
@@ -279,6 +280,7 @@ class PromoterActivityQuery(QueryBase):
             "prom": self.promoter_sequence,
             "orf": self.orf_sequence,
             "tissue_of_interest": self.tissue_of_interest,
+            "source": self.source,
         }
         return {
             "model": self.model,
@@ -314,6 +316,7 @@ class PromoterActivityQuery(QueryBase):
         fasta_path: str,
         orf_sequence: str,
         tissue_of_interest: Dict[str, List[str]],
+        source: str,
         model: str = "borzoi-human-fold0",
     ):
         """Return an iterator of PromoterActivityQuery objects from the promoter
@@ -338,6 +341,7 @@ class PromoterActivityQuery(QueryBase):
                 promoter_sequence=str(record.seq),
                 orf_sequence=orf_sequence,
                 tissue_of_interest=tissue_of_interest,
+                source=source,
                 model=model,
                 query_name=record.id,
             )
@@ -351,6 +355,7 @@ class PromoterActivityQuery(QueryBase):
         fasta_path: str,
         orf_sequence: str,
         tissue_of_interest: Dict[str, List[str]],
+        source: str,
         model: str = "borzoi-human-fold0",
     ):
         """Return a list of PromoterActivityQuery objects from the promoter sequences
@@ -372,6 +377,7 @@ class PromoterActivityQuery(QueryBase):
             fasta_path=fasta_path,
             orf_sequence=orf_sequence,
             tissue_of_interest=tissue_of_interest,
+            source=source,
             model=model,
         )
         return list(iterator)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -51,6 +51,7 @@ def test_promoter_activity():
     query = PromoterActivityQuery(
         promoter_sequence="tgccagccatctgttgtttgcc",
         orf_sequence="GTCCCACTGATGAACTGTGCT",
+        source="expression",
         tissue_of_interest={
             "heart": ["CNhs10608+", "CNhs10612+"],
             "liver": ["CNhs10608+", "CNhs10612+"],

--- a/test/test_query_creation.py
+++ b/test/test_query_creation.py
@@ -31,6 +31,7 @@ def test_promoter_activity_iteration():
     queries = PromoterActivityQuery.list_with_promoter_from_fasta(
         fasta_path=fasta_path,
         orf_sequence="GTCCCACTGATGAACTGTGCT",
+        source="expression",
         tissue_of_interest={
             "heart": ["CNhs10608+", "CNhs10612+"],
             "liver": ["CNhs10608+", "CNhs10612+"],


### PR DESCRIPTION
Small change to the Borzoi-based promoter activity prediction. A `source` field that takes either `binding` or `expression` values was added.  This enables the model to predict promoter activity from DNase-seq tracks as well as RNAseq tracks. 