### PR TITLE
Add lcdna endpoint

### DIFF
--- a/ginkgo_ai_client/__init__.py
+++ b/ginkgo_ai_client/__init__.py
@@ -6,6 +6,8 @@ from .queries import (
     MaskedInferenceQuery,
     MeanEmbeddingQuery,
     PromoterActivityQuery,
+    DiffusionMaskedQuery,
+    DiffusionMaskedResponse,
 )
 
 __all__ = [
@@ -13,4 +15,5 @@ __all__ = [
     "MaskedInferenceQuery",
     "MeanEmbeddingQuery",
     "PromoterActivityQuery",
+    "DiffusionMaskedQuery",
 ]

--- a/ginkgo_ai_client/queries.py
+++ b/ginkgo_ai_client/queries.py
@@ -451,7 +451,7 @@ class DiffusionMaskedQuery(QueryBase):
 
     def parse_response(self, results: Dict) -> DiffusionMaskedResponse:
         return DiffusionMaskedResponse(
-            sequence=results["sequence"],
+            sequence=results["sequence"][0],
             query_name=self.query_name,
         )
 

--- a/ginkgo_ai_client/queries.py
+++ b/ginkgo_ai_client/queries.py
@@ -48,6 +48,7 @@ _maskedlm_models_properties = {
     "esm2-3B": "protein",
     "ginkgo-maskedlm-3utr-v1": "dna",
     "lcdna": "nucleotide",
+    "abdiffusion": "protein",
 }
 
 _maskedlm_models_properties_str = "\n".join(

--- a/ginkgo_ai_client/queries.py
+++ b/ginkgo_ai_client/queries.py
@@ -47,6 +47,7 @@ _maskedlm_models_properties = {
     "esm2-650M": "protein",
     "esm2-3B": "protein",
     "ginkgo-maskedlm-3utr-v1": "dna",
+    "lcdna": "nucleotide",
 }
 
 _maskedlm_models_properties_str = "\n".join(
@@ -67,6 +68,11 @@ def _validate_model_and_sequence(model, sequence: str, allow_masks=False):
         if not set(sequence).issubset({"A", "T", "G", "C"}):
             raise ValueError(
                 f"Model {model} requires the sequence to only contain ATGC characters"
+            )
+    elif sequence_type == "nucleotide":
+        if not set(sequence.lower()).issubset({"a", "t", "g", "c", "r", "y", "s", "w", "k", "m", "b", "d", "h", "v", "n"}):
+            raise ValueError(
+                f"Model {model} requires the sequence to only contain valid IUPAC nucleotide characters"
             )
     elif sequence_type == "protein":
         if not set(sequence).issubset(set("ACDEFGHIKLMNPQRSTVWY")):
@@ -375,3 +381,98 @@ class PromoterActivityQuery(QueryBase):
             model=model,
         )
         return list(iterator)
+
+
+class DiffusionMaskedResponse(ResponseBase):
+    """A response to a DiffusionMaskedQuery, with attributes `sequence` (the predicted
+    sequence) and `query_name` (the original query's name).
+    """
+
+    sequence: str
+    query_name: Optional[str] = None
+
+
+class DiffusionMaskedQuery(QueryBase):
+    """A query to perform masked sampling using a diffusion model.
+
+    Parameters
+    ----------
+    sequence: str
+        Input sequence for masked sampling. The sequence may contain "<mask>" tokens.
+    temperature: float, optional (default=0.5)
+        Sampling temperature, a value between 0 and 1.
+    decoding_order_strategy: str, optional (default="entropy")
+        Strategy for decoding order, must be either "max_prob" or "entropy".
+    unmaskings_per_step: int, optional (default=50)
+        Number of tokens to unmask per step, an integer between 1 and 1000.
+    model: str
+        The model to use for the inference.
+    query_name: Optional[str] = None
+        The name of the query. It will appear in the API response and can be used to handle exceptions.
+
+    Returns
+    -------
+    DiffusionMaskedResponse
+        ``client.send_request(query)`` returns a ``DiffusionMaskedResponse`` with attributes
+        ``sequence`` (the predicted sequence) and ``query_name`` (the original query's name).
+
+    Examples
+    --------
+    >>> query = DiffusionMaskedQuery(
+    ...     sequence="ATTG<mask>TAC",
+    ...     model="lcdna",
+    ...     temperature=0.7,
+    ...     decoding_order_strategy="entropy",
+    ...     unmaskings_per_step=20,
+    ... )
+    >>> client.send_request(query)
+    DiffusionMaskedResponse(sequence="ATTGCGTAC", query_name=None)
+    """
+
+    sequence: str
+    temperature: float = 0.5
+    decoding_order_strategy: str = "entropy"
+    unmaskings_per_step: int = 50
+    model: str
+    query_name: Optional[str] = None
+
+    def to_request_params(self) -> Dict:
+        data = {
+            "sequence": self.sequence,
+            "temperature": self.temperature,
+            "decoding_order_strategy": self.decoding_order_strategy,
+            "unmaskings_per_step": self.unmaskings_per_step,
+        }
+        return {
+            "model": self.model,
+            "text": json.dumps(data),
+            "transforms": [{"type": "DIFFUSION_GENERATE"}],
+        }
+
+    def parse_response(self, results: Dict) -> DiffusionMaskedResponse:
+        return DiffusionMaskedResponse(
+            sequence=results["sequence"],
+            query_name=self.query_name,
+        )
+
+    @pydantic.model_validator(mode="after")
+    def validate_query(cls, query):
+        sequence, model = query.sequence, query.model
+        # Validate sequence and model compatibility
+        _validate_model_and_sequence(
+            model=model,
+            sequence=sequence,
+            allow_masks=True,
+        )
+        # Validate temperature
+        if not 0 <= query.temperature <= 1:
+            raise ValueError("temperature must be between 0 and 1")
+        # Validate decoding_order_strategy
+        if query.decoding_order_strategy not in ["max_prob", "entropy"]:
+            raise ValueError(
+                "decoding_order_strategy must be 'max_prob' or 'entropy'"
+            )
+        # Validate unmaskings_per_step
+        if not 1 <= query.unmaskings_per_step <= 1000:
+            raise ValueError("unmaskings_per_step must be between 1 and 1000")
+        return query

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ biopython==1.82.0
 pytest-xdist==3.6.1
 pytest-cov==4.0.0
 
-sphinx==8.1.3,
-docutils==0.21.2,
-myst-parser==4.0.0,
+sphinx==8.1.3
+docutils==0.21.2
+myst-parser==4.0.0
 shibuya==2024.10.15
+tqdm==4.67.1
+pydantic==2.10.3

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -15,7 +15,7 @@ from ginkgo_ai_client import (
         ("ginkgo-aa0-650M", "MCL<mask>YAFVATDA<mask>DDT", "MCLLYAFVATDADDDT"),
         ("esm2-650M", "MCL<mask>YAFVATDA<mask>DDT", "MCLLYAFVATDAADDT"),
         ("ginkgo-maskedlm-3utr-v1", "ATTG<mask>G", "ATTGGG"),
-        ("lcdna", "ATRGAyAtg<mask>TAC<mask>", "ATRGAyAtgTAC"),
+        ("lcdna", "ATRGAyAtg<mask>TAC<mask>", "atggatatgtta<unk>"),
     ],
 )
 def test_masked_inference(model, sequence, expected_sequence):

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -5,6 +5,7 @@ from ginkgo_ai_client import (
     MaskedInferenceQuery,
     MeanEmbeddingQuery,
     PromoterActivityQuery,
+    DiffusionMaskedQuery,
 )
 
 
@@ -14,6 +15,7 @@ from ginkgo_ai_client import (
         ("ginkgo-aa0-650M", "MCL<mask>YAFVATDA<mask>DDT", "MCLLYAFVATDADDDT"),
         ("esm2-650M", "MCL<mask>YAFVATDA<mask>DDT", "MCLLYAFVATDAADDT"),
         ("ginkgo-maskedlm-3utr-v1", "ATTG<mask>G", "ATTGGG"),
+        ("lcdna", "ATRGAyAtg<mask>TAC<mask>", "ATRGAyAtgTAC"),
     ],
 )
 def test_masked_inference(model, sequence, expected_sequence):
@@ -60,3 +62,17 @@ def test_promoter_activity():
     response = client.send_request(query)
     assert "heart" in response.activity_by_tissue
     assert "liver" in response.activity_by_tissue
+
+
+def test_diffusion_masked_inference():
+    client = GinkgoAIClient()
+    query = DiffusionMaskedQuery(
+        sequence="ATRGAyAtg<mask>TAC<mask>",  #upper and lower cases
+        model="lcdna",
+        temperature=0.5,
+        decoding_order_strategy="entropy",
+        unmaskings_per_step=2,
+    )
+    response = client.send_request(query)
+    assert isinstance(response.sequence, str)
+    assert "<mask>" not in response.sequence

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -63,12 +63,18 @@ def test_promoter_activity():
     assert "heart" in response.activity_by_tissue
     assert "liver" in response.activity_by_tissue
 
-
-def test_diffusion_masked_inference():
+@pytest.mark.parametrize(
+    "model, sequence, expected_sequence",
+    [
+        ("lcdna", "ATRGAyAtg<mask>TAC<mask>"),
+        ("abdiffusion", "MCL<mask>YAFVATDA<mask>DDT"),
+    ],
+)
+def test_diffusion_masked_inference(model, sequence):
     client = GinkgoAIClient()
     query = DiffusionMaskedQuery(
-        sequence="ATRGAyAtg<mask>TAC<mask>",  #upper and lower cases
-        model="lcdna",
+        sequence=sequence,  #upper and lower cases
+        model=model,
         temperature=0.5,
         decoding_order_strategy="entropy",
         unmaskings_per_step=2,

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -64,7 +64,7 @@ def test_promoter_activity():
     assert "liver" in response.activity_by_tissue
 
 @pytest.mark.parametrize(
-    "model, sequence, expected_sequence",
+    "model, sequence",
     [
         ("lcdna", "ATRGAyAtg<mask>TAC<mask>"),
         ("abdiffusion", "MCL<mask>YAFVATDA<mask>DDT"),


### PR DESCRIPTION
This MR is intended to add client support for the long-context DNA diffusion model. The external endpoint is not yet active, so the tests won't pass until it is up.